### PR TITLE
Fix: Parse integer value from php.ini memor_limit

### DIFF
--- a/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
+++ b/Classes/PHPExcel/Shared/PCLZip/pclzip.lib.php
@@ -1729,17 +1729,17 @@ class PclZip
 
         if ($last == 'g') {
             //$v_memory_limit = $v_memory_limit*1024*1024*1024;
-            $v_memory_limit = $v_memory_limit*1073741824;
+            $v_memory_limit = intval($v_memory_limit)*1073741824;
         }
         if ($last == 'm') {
             //$v_memory_limit = $v_memory_limit*1024*1024;
-            $v_memory_limit = $v_memory_limit*1048576;
+            $v_memory_limit = intval($v_memory_limit)*1048576;
         }
         if ($last == 'k') {
-            $v_memory_limit = $v_memory_limit*1024;
+            $v_memory_limit = intval($v_memory_limit)*1024;
         }
 
-        $p_options[PCLZIP_OPT_TEMP_FILE_THRESHOLD] = floor($v_memory_limit*PCLZIP_TEMPORARY_FILE_RATIO);
+        $p_options[PCLZIP_OPT_TEMP_FILE_THRESHOLD] = floor(intval($v_memory_limit)*PCLZIP_TEMPORARY_FILE_RATIO);
 
         // ----- Sanity check : No threshold if value lower than 1M
         if ($p_options[PCLZIP_OPT_TEMP_FILE_THRESHOLD] < 1048576) {


### PR DESCRIPTION
This is compatibility fix for PHP7, when notice "A non well formed numeric value encountered" is thrown after attempt to multiply number string for example "512M" with number.

PHP <7 silently truncated any non number character before multiplication was done.